### PR TITLE
Optimize min/max level reduction with single MPI call

### DIFF
--- a/include/samurai/io/hdf5.hpp
+++ b/include/samurai/io/hdf5.hpp
@@ -361,8 +361,12 @@ namespace samurai
         {
 #ifdef SAMURAI_WITH_MPI
             mpi::communicator world;
-            auto min_level = mpi::all_reduce(world, this->mesh().min_level(), mpi::minimum<std::size_t>());
-            auto max_level = mpi::all_reduce(world, this->mesh().max_level(), mpi::maximum<std::size_t>());
+            std::array<std::size_t, 2> levels{this->mesh().min_level(), this->mesh().max_level()};
+            levels = mpi::all_reduce(world, levels, [](const auto& a, const auto& b) {
+                return std::array<std::size_t, 2>{std::min(a[0], b[0]), std::max(a[1], b[1])};
+            });
+            auto min_level = levels[0];
+            auto max_level = levels[1];
 #else
             auto min_level = this->mesh().min_level();
             auto max_level = this->mesh().max_level();


### PR DESCRIPTION
## Summary
- reduce min/max level fetches to a single MPI all_reduce in mesh and IO code
- include necessary headers for new array-based reduction

## Testing
- `pytest -q` *(fails: FileNotFoundError: '../build/demos/FiniteVolume/Release/finite-volume-level-set-from-scratch')*


------
https://chatgpt.com/codex/tasks/task_e_68b2051332048332a9e0f416cf782705