### PR TITLE
Rename local std variable in MPI timers

### DIFF
--- a/include/samurai/timers.hpp
+++ b/include/samurai/timers.hpp
@@ -134,7 +134,7 @@ namespace samurai
             {
                 int minrank = -1, maxrank = -1;
                 double min = std::numeric_limits<double>::max(), max = std::numeric_limits<double>::lowest();
-                double ave = 0., std = 0.;
+                double ave = 0., std_dev = 0.;
 
                 std::vector<double> all(static_cast<std::size_t>(world.size()), 0.0);
                 boost::mpi::all_gather(world, timer.second.elapsed, all);
@@ -164,7 +164,7 @@ namespace samurai
                     const double d = all[iproc] - ave;
                     sqsum += d * d;
                 }
-                std = std::sqrt(sqsum / static_cast<double>(world.size()));
+                std_dev = std::sqrt(sqsum / static_cast<double>(world.size()));
 
                 // boost::mpi::reduce( world, timer.second.elapsed, min, boost::mpi::minimum<double>(), root );
                 // boost::mpi::reduce( world, timer.second.elapsed, max, boost::mpi::maximum<double>(), root );
@@ -185,7 +185,7 @@ namespace samurai
                                rankWidth,
                                ave,
                                timeWidth,
-                               std,
+                               std_dev,
                                timeWidth,
                                timer.second.ntimes,
                                callsWidth);


### PR DESCRIPTION
## Summary
- avoid shadowing the standard namespace in MPI timers by renaming the `std` variable to `std_dev`
- update standard deviation calculation and formatting to use the new variable

## Testing
- `g++ -std=c++17 -Iinclude -I/usr/include/x86_64-linux-gnu/mpi -c /tmp/test.cpp`
- `cmake -S . -B build -DWITH_MPI=ON -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DBUILD_DEMOS=OFF` *(fails: Could not find a package configuration file provided by "HighFive")*


------
https://chatgpt.com/codex/tasks/task_e_68c311429cf88332bc2b79d299c8ab80